### PR TITLE
fix key error when no quantization info in tflite file

### DIFF
--- a/tflite-onnx/onnx_tflite/aact_layers.py
+++ b/tflite-onnx/onnx_tflite/aact_layers.py
@@ -182,7 +182,7 @@ class Relu(Layer):
         self.node_list.append(relu_node)
 
         #Generate Quantization Info and Reverse Quantization for Weights and Bias
-        output_quantization_info = node_output_detail["quantization_parameters"]
+        output_quantization_info = node_output_detail.get("quantization_parameters", {})
         output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
         quantization_info = {}
         quantization_info[self.node_name] = output_quantization_info
@@ -229,7 +229,7 @@ class Relu6(Layer):
         self.node_list.append(clip_node)
 
         #Generate Quantization Info and Reverse Quantization for Weights and Bias
-        output_quantization_info = node_output_detail["quantization_parameters"]
+        output_quantization_info = node_output_detail.get("quantization_parameters", {})
         output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
         quantization_info = {}
         quantization_info[self.node_name] = output_quantization_info
@@ -313,7 +313,7 @@ class PRelu(Layer):
         self.value_infos.append(out_shape_info)
 
         #Generate Quantization Info and Reverse Quantization for Weights and Bias
-        output_quantization_info = node_output_detail["quantization_parameters"]
+        output_quantization_info = node_output_detail.get("quantization_parameters", {})
         output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
         quantization_info = {}
         quantization_info[self.node_name] = output_quantization_info

--- a/tflite-onnx/onnx_tflite/conv_layers.py
+++ b/tflite-onnx/onnx_tflite/conv_layers.py
@@ -59,10 +59,10 @@ class Convolution(Layer):
       input_quantization_info["bias"] = bias_quantization_info
 
       weights_array = np.array(weights_array, dtype = np.dtype("f4"))
-      if weight_quantization_info["scales"]:
+      if "scales" in weight_quantization_info and len(weight_quantization_info["scales"]) > 0:
           weights_array = (weights_array - weight_quantization_info["zero_points"][0]) * weight_quantization_info["scales"][0]
       bias_array = np.array(bias_array, dtype = np.dtype("f4"))
-      if bias_quantization_info["scales"]:
+      if "scales" in bias_quantization_info and len(bias_quantization_info["scales"]) > 0:
           bias_array = (bias_array - bias_quantization_info["zero_points"][0]) * bias_quantization_info["scales"][0]
 
       padding_stradegy = 'NONE'
@@ -175,10 +175,10 @@ class DepthwiseConvolution(Layer):
       input_quantization_info["bias"] = bias_quantization_info
 
       weights_array = np.array(weights_array, dtype = np.dtype("f4"))
-      if weight_quantization_info["scales"]:
+      if "scales" in weight_quantization_info and len(weight_quantization_info["scales"]) > 0:
           weights_array = (weights_array - weight_quantization_info["zero_points"][0]) * weight_quantization_info["scales"][0]
       bias_array = np.array(bias_array, dtype = np.dtype("f4"))
-      if bias_quantization_info["scales"]:
+      if "scales" in bias_quantization_info and len(bias_quantization_info["scales"]) > 0:
           bias_array = (bias_array - bias_quantization_info["zero_points"][0]) * bias_quantization_info["scales"][0]
 
       kernel_shape=[weights_array.shape[1], weights_array.shape[2]]
@@ -421,7 +421,7 @@ class TransposeConvolution(Layer):
       weight_quantization_info = weights_node_info.get("quantization_parameters", {})
       weight_quantization_info["dtype"] = str(weights_node_info["dtype"]).split(".")[1].split("'")[0]
       weights_array = np.array(weights_array, dtype = np.dtype("f4"))
-      if weight_quantization_info["scales"]:
+      if "scales" in weight_quantization_info and len(weight_quantization_info["scales"]) > 0:
           weights_array = (weights_array - weight_quantization_info["zero_points"][0]) * weight_quantization_info["scales"][0]
       #Nested weight quantization info into input
       input_quantization_info["weight"] = weight_quantization_info

--- a/tflite-onnx/onnx_tflite/conv_layers.py
+++ b/tflite-onnx/onnx_tflite/conv_layers.py
@@ -41,13 +41,13 @@ class Convolution(Layer):
       dilation_factor = [self.tflite_conv_parser.DilationHFactor(), self.tflite_conv_parser.DilationWFactor()]
 
       #Generate Quantization Info and Reverse Quantization for Weights and Bias
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
-      input_quantization_info = node_input_detail["quantization_parameters"]
+      input_quantization_info = node_input_detail.get("quantization_parameters", {})
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
-      weight_quantization_info = weights_node_info["quantization_parameters"]
+      weight_quantization_info = weights_node_info.get("quantization_parameters", {})
       weight_quantization_info["dtype"] = str(weights_node_info["dtype"]).split(".")[1].split("'")[0]
-      bias_quantization_info = bias_node_info["quantization_parameters"]
+      bias_quantization_info = bias_node_info.get("quantization_parameters", {})
       bias_quantization_info["dtype"] = str(bias_node_info["dtype"]).split(".")[1].split("'")[0]
 
     #   input_quantization_info_clean = utils.get_quantization_info_in_array(input_quantization_info)
@@ -162,13 +162,13 @@ class DepthwiseConvolution(Layer):
       bias_array = self.tflite_interpreter.get_tensor(bias_node_info['index'])
       
       #Generate Quantization Info and Reverse Quantization for Weights and Bias
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
-      input_quantization_info = node_input_detail["quantization_parameters"]
+      input_quantization_info = node_input_detail.get("quantization_parameters", {})
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
-      weight_quantization_info = weights_node_info["quantization_parameters"]
+      weight_quantization_info = weights_node_info.get("quantization_parameters", {})
       weight_quantization_info["dtype"] = str(weights_node_info["dtype"]).split(".")[1].split("'")[0]
-      bias_quantization_info = bias_node_info["quantization_parameters"]
+      bias_quantization_info = bias_node_info.get("quantization_parameters", {})
       bias_quantization_info["dtype"] = str(bias_node_info["dtype"]).split(".")[1].split("'")[0]
       #Nested weight and bias into input
       input_quantization_info["weight"] =  weight_quantization_info
@@ -414,11 +414,11 @@ class TransposeConvolution(Layer):
       strides_len = [self.tflite_tconv_parser.StrideH(),self.tflite_tconv_parser.StrideW()]
 
       #Generate Quantization Info and Reverse Quantization for Weights and Bias
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
-      input_quantization_info = node_input_detail["quantization_parameters"]
+      input_quantization_info = node_input_detail.get("quantization_parameters", {})
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
-      weight_quantization_info = weights_node_info["quantization_parameters"]
+      weight_quantization_info = weights_node_info.get("quantization_parameters", {})
       weight_quantization_info["dtype"] = str(weights_node_info["dtype"]).split(".")[1].split("'")[0]
       weights_array = np.array(weights_array, dtype = np.dtype("f4"))
       if weight_quantization_info["scales"]:

--- a/tflite-onnx/onnx_tflite/core_layers.py
+++ b/tflite-onnx/onnx_tflite/core_layers.py
@@ -87,7 +87,7 @@ class Dense(Layer):
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
       weight_quantization_info = weights_node_info.get("quantization_parameters", {})
       weight_quantization_info["dtype"] = str(weights_node_info["dtype"]).split(".")[1].split("'")[0]
-      if weight_quantization_info["scales"]:
+      if "scales" in weight_quantization_info and len(weight_quantization_info["scales"]) > 0:
           weights_array = (weights_array - weight_quantization_info["zero_points"][0]) * weight_quantization_info["scales"][0]
       #Nested weight quantization into input
       input_quantization_info["weight"] = weight_quantization_info
@@ -132,7 +132,7 @@ class Dense(Layer):
 
           bias_quantization_info = bias_node_info.get("quantization_parameters", {})
           bias_quantization_info["dtype"] = str(bias_node_info["dtype"]).split(".")[1].split("'")[0]
-          if bias_quantization_info["scales"]:
+          if "scales" in bias_quantization_info and len(bias_quantization_info["scales"]) > 0:
               bias_array = (bias_array - bias_quantization_info["zero_points"][0]) * bias_quantization_info["scales"][0]
 
           # make bias onnx node
@@ -280,7 +280,8 @@ class Reshape(Layer):
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
       quantization_info = {}
       quantization_info[reshape_node_name] = input_quantization_info
-      quantization_info[transpose_after_node_name] = output_quantization_info
+      if self.tflite_reshape_parser:
+        quantization_info[transpose_after_node_name] = output_quantization_info
 
       return self.node_list, self.value_infos, self.weight_node_list, quantization_info
 

--- a/tflite-onnx/onnx_tflite/core_layers.py
+++ b/tflite-onnx/onnx_tflite/core_layers.py
@@ -81,11 +81,11 @@ class Dense(Layer):
       weights_array = self.tflite_interpreter.get_tensor(weights_node_info['index'])
 
       #Generate Quantization Info and Reverse Quantization for Weights and Bias
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
-      input_quantization_info = node_input_detail["quantization_parameters"]
+      input_quantization_info = node_input_detail.get("quantization_parameters", {})
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
-      weight_quantization_info = weights_node_info["quantization_parameters"]
+      weight_quantization_info = weights_node_info.get("quantization_parameters", {})
       weight_quantization_info["dtype"] = str(weights_node_info["dtype"]).split(".")[1].split("'")[0]
       if weight_quantization_info["scales"]:
           weights_array = (weights_array - weight_quantization_info["zero_points"][0]) * weight_quantization_info["scales"][0]
@@ -130,7 +130,7 @@ class Dense(Layer):
           bias_node_info = self.tflite_interpreter._get_tensor_details(self.op.Inputs(2))
           bias_array = self.tflite_interpreter.get_tensor(bias_node_info['index'])
 
-          bias_quantization_info = bias_node_info["quantization_parameters"]
+          bias_quantization_info = bias_node_info.get("quantization_parameters", {})
           bias_quantization_info["dtype"] = str(bias_node_info["dtype"]).split(".")[1].split("'")[0]
           if bias_quantization_info["scales"]:
               bias_array = (bias_array - bias_quantization_info["zero_points"][0]) * bias_quantization_info["scales"][0]
@@ -274,9 +274,9 @@ class Reshape(Layer):
                 if o_n_i_n == self.node_name:
                    o_n.input_nodes_name[idx] = transpose_after_node_name
         
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
-      input_quantization_info = node_input_detail["quantization_parameters"]
+      input_quantization_info = node_input_detail.get("quantization_parameters", {})
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
       quantization_info = {}
       quantization_info[reshape_node_name] = input_quantization_info

--- a/tflite-onnx/onnx_tflite/pool_layers.py
+++ b/tflite-onnx/onnx_tflite/pool_layers.py
@@ -57,9 +57,9 @@ class MaxPooling2D(Layer):
       self.node_list.append(max_pool_node)
       
       #Generate Quantization Info and Reverse Quantization for Weights and Bias
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
-      input_quantization_info = node_input_detail["quantization_parameters"]
+      input_quantization_info = node_input_detail.get("quantization_parameters", {})
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
       quantization_info = {}
       quantization_info[self.input_nodes_name[0]] = input_quantization_info
@@ -118,9 +118,9 @@ class AveragePooling2D(Layer):
       self.node_list.append(avg_pool_node)
 
       #Generate Quantization Info and Reverse Quantization for Weights and Bias
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
-      input_quantization_info = node_input_detail["quantization_parameters"]
+      input_quantization_info = node_input_detail.get("quantization_parameters", {})
       input_quantization_info["dtype"] = str(node_input_detail["dtype"]).split(".")[1].split("'")[0]
       quantization_info = {}
       quantization_info[self.input_nodes_name[0]] = input_quantization_info
@@ -193,7 +193,7 @@ class Mean(Layer):
       ##################  add squeeze  ###############
 
       #Generate Quantization Info and Reverse Quantization for Weights and Bias
-      output_quantization_info = node_output_detail["quantization_parameters"]
+      output_quantization_info = node_output_detail.get("quantization_parameters", {})
       output_quantization_info["dtype"] = str(node_output_detail["dtype"]).split(".")[1].split("'")[0]
       quantization_info = {}
       quantization_info[mean_node_name] = output_quantization_info

--- a/tflite-onnx/onnx_tflite/tflite2onnx.py
+++ b/tflite-onnx/onnx_tflite/tflite2onnx.py
@@ -155,11 +155,17 @@ def merge_quantization_info(dumped_info, quantization_info):
         curr_dict["scales"] = curr_dict["scales"].tolist()
         curr_dict["zero_points"] = curr_dict["zero_points"].tolist()
 
+        print(quantization_info)
+        print(curr_dict)
         dumped_dict = {}
-        dumped_dict["min"] = curr_dict["min"]
-        dumped_dict["max"] = curr_dict["max"]
-        dumped_dict["desired_radix"] = curr_dict["radix"]
-        dumped_dict["desired_scale"] = curr_dict["scale"]
+        if "min" in curr_dict:
+            dumped_dict["min"] = curr_dict["min"]
+        if "max" in curr_dict:
+            dumped_dict["max"] = curr_dict["max"]
+        if "radix" in curr_dict:
+            dumped_dict["desired_radix"] = curr_dict["radix"]
+        if "scale" in curr_dict:
+            dumped_dict["desired_scale"] = curr_dict["scale"]
 
         dumped_info[name] = dumped_dict
     
@@ -211,10 +217,14 @@ def merge_nested_quantization_info(dumped_info, quantization_info, name):
             quantization_info["scale"] = {"all":kneron_scales[0]}
 
     dumped_dict = {}
-    dumped_dict["min"] = quantization_info["min"]
-    dumped_dict["max"] = quantization_info["max"]
-    dumped_dict["desired_scale"] = quantization_info["scale"]
-    dumped_dict["desired_radix"] = quantization_info["radix"]
+    if "min" in quantization_info:
+        dumped_dict["min"] = quantization_info["min"]
+    if "max" in quantization_info:
+        dumped_dict["max"] = quantization_info["max"]
+    if "scale" in quantization_info:
+        dumped_dict["desired_scale"] = quantization_info["scale"]
+    if "radix" in quantization_info:
+        dumped_dict["desired_radix"] = quantization_info["radix"]
 
     dumped_info[name] = dumped_dict
     return 

--- a/tflite-onnx/onnx_tflite/tflite2onnx.py
+++ b/tflite-onnx/onnx_tflite/tflite2onnx.py
@@ -202,7 +202,7 @@ def merge_nested_quantization_info(dumped_info, quantization_info, name):
 
 def check_quantization(tensor_details):
     for node_detail in tensor_details:
-        if len(node_detail["quantization_parameters"]["scales"] > 0):
+        if "quantization_parameters" in node_detail["quantization_parameters"] and len(node_detail["quantization_parameters"]["scales"]) > 0:
             return True
     return False 
 

--- a/tflite-onnx/onnx_tflite/tflite2onnx.py
+++ b/tflite-onnx/onnx_tflite/tflite2onnx.py
@@ -123,10 +123,11 @@ def merge_quantization_info(dumped_info, quantization_info):
                 curr_dict["max"] = {"all":maxs[0]}
             
             def get_radix(scale, max_perchannel, min_perchannel):
-                range_tflite = max_perchannel - min_perchannel
+                # range_tflite = max_perchannel - min_perchannel
+                # ratio = range_tflite / range_kneron
+                # radix = math.floor(math.log(ratio / scale, 2))
                 range_kneron = max(abs(max_perchannel), abs(min_perchannel)) * 2
-                ratio = range_tflite / range_kneron
-                radix = math.floor(math.log(ratio / scale, 2))
+                radix = math.floor(math.log((1 << 8) / range_kneron, 2))
                 return radix
 
             # radixs = [int(1 / scales[i]).bit_length() - 1 for i in range(len(zero_points))]
@@ -138,25 +139,23 @@ def merge_quantization_info(dumped_info, quantization_info):
 
             kneron_scales = []
             for i in range(len(zero_points)):
-                if radixs[i] >= 0:
-                    kneron_scales.append(1 / ((1 << radixs[i]) * scales[i]))
-                elif radixs[i] < 0:
-                    kneron_scales.append((1 / 2 **(-radixs[i])) * scales[i]) 
+                uppper_limit = 1 << (7 - radixs[i]) if (7 - radixs[i]) >= 0 else  1 >> (radixs[i] - 7)
+                curr_upper_limit = max(abs(maxs[i]), abs(mins[i]))
+                kneron_scales.append(uppper_limit/curr_upper_limit)
+
 
             curr_dict["scale"] = kneron_scales
             if len(kneron_scales) == 1:
                 curr_dict["scale"] = {"all":kneron_scales[0]}
 
-            if "weight" in quantization_info[name]:
-                merge_nested_quantization_info(curr_dict, quantization_info[name]["weight"], "weight")
-            if "bias" in quantization_info[name]:
-                merge_nested_quantization_info(curr_dict, quantization_info[name]["bias"], "bias") 
+            # if "weight" in quantization_info[name]:
+            #     merge_nested_quantization_info(curr_dict, quantization_info[name]["weight"], "weight")
+            # if "bias" in quantization_info[name]:
+            #     merge_nested_quantization_info(curr_dict, quantization_info[name]["bias"], "bias") 
 
         curr_dict["scales"] = curr_dict["scales"].tolist()
         curr_dict["zero_points"] = curr_dict["zero_points"].tolist()
 
-        print(quantization_info)
-        print(curr_dict)
         dumped_dict = {}
         if "min" in curr_dict:
             dumped_dict["min"] = curr_dict["min"]
@@ -296,7 +295,6 @@ def main(model_path, model_save_path=None, add_transpose_for_channel_last_first_
             onnx_node_list.extend(nodes)
         if len(quantization_info) != 0:
             merge_quantization_info(dumped_quantization_info, quantization_info)
-            #print(dumped_quantization_info)
 
     if check_quantization(interpreter.get_tensor_details()): 
         json_save_path = model_save_path[:-5] + "_user_config.json"

--- a/tflite-onnx/onnx_tflite/tree_structure.py
+++ b/tflite-onnx/onnx_tflite/tree_structure.py
@@ -210,7 +210,7 @@ class Tree:
             layer_scale, layer_zero_point = item["quantization"]
             layer_min = (0 - layer_zero_point) * layer_scale
             layer_max = (255 - layer_zero_point) * layer_scale
-            if item["quantization"] != (0.0, 0):
+            if item["quantization"] != (0.0, 0) and layer_min == 0:
                 quantized_node_list.append(item["name"])
                 quantized_node_map[item["name"]] = (layer_min, layer_max)
         


### PR DESCRIPTION
The 3 models provided by Eric can pass tflite2onnx.py without this commit on my local machine.
I still modify code a little to prevent errors when no quantization info provided by .tflite file.
